### PR TITLE
Added redirects for pythonSoftIOC

### DIFF
--- a/pythonSoftIOC/3.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/_modules/index.html
+++ b/pythonSoftIOC/3.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/3.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/explanations/why-use-pythonIoc.html
+++ b/pythonSoftIOC/3.0/explanations/why-use-pythonIoc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/explanations/why-use-pythonIoc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/explanations/why-use-pythonIoc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/explanations/why-use-pythonIoc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/genindex.html
+++ b/pythonSoftIOC/3.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/3.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/3.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/index.html
+++ b/pythonSoftIOC/3.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/py-modindex.html
+++ b/pythonSoftIOC/3.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/reference/api.html
+++ b/pythonSoftIOC/3.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/reference/changelog.html
+++ b/pythonSoftIOC/3.0/reference/changelog.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/reference/changelog.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/reference/changelog.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/reference/changelog.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/reference/contributing.html
+++ b/pythonSoftIOC/3.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/search.html
+++ b/pythonSoftIOC/3.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0/tutorials/installation.html
+++ b/pythonSoftIOC/3.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.0b1/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/index.html
+++ b/pythonSoftIOC/3.0b1/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/3.0b1/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.0b1/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.0b1/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.0b1/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/explanations/index.html
+++ b/pythonSoftIOC/3.0b1/explanations/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/explanations/why-use-pythonIoc.html
+++ b/pythonSoftIOC/3.0b1/explanations/why-use-pythonIoc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/why-use-pythonIoc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/why-use-pythonIoc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/explanations/why-use-pythonIoc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/genindex.html
+++ b/pythonSoftIOC/3.0b1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/how-to/index.html
+++ b/pythonSoftIOC/3.0b1/how-to/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.0b1/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/index.html
+++ b/pythonSoftIOC/3.0b1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/py-modindex.html
+++ b/pythonSoftIOC/3.0b1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/reference/api.html
+++ b/pythonSoftIOC/3.0b1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/reference/contributing.html
+++ b/pythonSoftIOC/3.0b1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/reference/index.html
+++ b/pythonSoftIOC/3.0b1/reference/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/reference/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/search.html
+++ b/pythonSoftIOC/3.0b1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.0b1/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/tutorials/index.html
+++ b/pythonSoftIOC/3.0b1/tutorials/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b1/tutorials/installation.html
+++ b/pythonSoftIOC/3.0b1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b1/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.0b2/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/index.html
+++ b/pythonSoftIOC/3.0b2/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/3.0b2/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.0b2/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.0b2/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.0b2/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/explanations/why-use-pythonIoc.html
+++ b/pythonSoftIOC/3.0b2/explanations/why-use-pythonIoc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/explanations/why-use-pythonIoc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/explanations/why-use-pythonIoc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/explanations/why-use-pythonIoc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/genindex.html
+++ b/pythonSoftIOC/3.0b2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.0b2/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/index.html
+++ b/pythonSoftIOC/3.0b2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/py-modindex.html
+++ b/pythonSoftIOC/3.0b2/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/reference/api.html
+++ b/pythonSoftIOC/3.0b2/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/reference/contributing.html
+++ b/pythonSoftIOC/3.0b2/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/search.html
+++ b/pythonSoftIOC/3.0b2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.0b2/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.0b2/tutorials/installation.html
+++ b/pythonSoftIOC/3.0b2/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.0b2/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.1/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/index.html
+++ b/pythonSoftIOC/3.1/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/3.1/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.1/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.1/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.1/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/explanations/why-use-pythonIoc.html
+++ b/pythonSoftIOC/3.1/explanations/why-use-pythonIoc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/explanations/why-use-pythonIoc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/explanations/why-use-pythonIoc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/explanations/why-use-pythonIoc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/genindex.html
+++ b/pythonSoftIOC/3.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/3.1/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/3.1/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.1/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/index.html
+++ b/pythonSoftIOC/3.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/py-modindex.html
+++ b/pythonSoftIOC/3.1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/reference/api.html
+++ b/pythonSoftIOC/3.1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/reference/changelog.html
+++ b/pythonSoftIOC/3.1/reference/changelog.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/reference/changelog.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/reference/changelog.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/reference/changelog.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/reference/contributing.html
+++ b/pythonSoftIOC/3.1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/search.html
+++ b/pythonSoftIOC/3.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.1/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.1/tutorials/installation.html
+++ b/pythonSoftIOC/3.1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.1/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.2.1/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/_modules/index.html
+++ b/pythonSoftIOC/3.2.1/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.2.1/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.2.1/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.2.1/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/3.2.1/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/3.2.1/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/genindex.html
+++ b/pythonSoftIOC/3.2.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/3.2.1/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/3.2.1/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.2.1/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/how-to/use-soft-records.html
+++ b/pythonSoftIOC/3.2.1/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/index.html
+++ b/pythonSoftIOC/3.2.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/py-modindex.html
+++ b/pythonSoftIOC/3.2.1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/reference/api.html
+++ b/pythonSoftIOC/3.2.1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/reference/contributing.html
+++ b/pythonSoftIOC/3.2.1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/search.html
+++ b/pythonSoftIOC/3.2.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.2.1/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2.1/tutorials/installation.html
+++ b/pythonSoftIOC/3.2.1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2.1/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/3.2/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/_modules/index.html
+++ b/pythonSoftIOC/3.2/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/_modules/softioc/builder.html
+++ b/pythonSoftIOC/3.2/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/_modules/softioc/device.html
+++ b/pythonSoftIOC/3.2/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/3.2/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/3.2/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/3.2/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/genindex.html
+++ b/pythonSoftIOC/3.2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/3.2/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/3.2/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/3.2/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/how-to/use-soft-records.html
+++ b/pythonSoftIOC/3.2/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/index.html
+++ b/pythonSoftIOC/3.2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/py-modindex.html
+++ b/pythonSoftIOC/3.2/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/reference/api.html
+++ b/pythonSoftIOC/3.2/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/reference/contributing.html
+++ b/pythonSoftIOC/3.2/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/search.html
+++ b/pythonSoftIOC/3.2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/3.2/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/3.2/tutorials/installation.html
+++ b/pythonSoftIOC/3.2/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/3.2/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.0.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/_modules/index.html
+++ b/pythonSoftIOC/4.0.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.0.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.0.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.0.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.0.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.0.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/genindex.html
+++ b/pythonSoftIOC/4.0.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.0.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.0.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.0.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.0.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/index.html
+++ b/pythonSoftIOC/4.0.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/py-modindex.html
+++ b/pythonSoftIOC/4.0.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/reference/api.html
+++ b/pythonSoftIOC/4.0.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/reference/contributing.html
+++ b/pythonSoftIOC/4.0.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/search.html
+++ b/pythonSoftIOC/4.0.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.0.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.0.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.0.1/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/_modules/index.html
+++ b/pythonSoftIOC/4.0.1/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.0.1/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.0.1/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.0.1/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.0.1/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.0.1/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/genindex.html
+++ b/pythonSoftIOC/4.0.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.0.1/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.0.1/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.0.1/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.0.1/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/index.html
+++ b/pythonSoftIOC/4.0.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/py-modindex.html
+++ b/pythonSoftIOC/4.0.1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/reference/api.html
+++ b/pythonSoftIOC/4.0.1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/reference/contributing.html
+++ b/pythonSoftIOC/4.0.1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/search.html
+++ b/pythonSoftIOC/4.0.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.0.1/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.1/tutorials/installation.html
+++ b/pythonSoftIOC/4.0.1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.1/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.0.2/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/_modules/index.html
+++ b/pythonSoftIOC/4.0.2/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.0.2/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.0.2/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.0.2/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.0.2/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.0.2/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/genindex.html
+++ b/pythonSoftIOC/4.0.2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.0.2/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.0.2/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.0.2/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.0.2/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/index.html
+++ b/pythonSoftIOC/4.0.2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/py-modindex.html
+++ b/pythonSoftIOC/4.0.2/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/reference/api.html
+++ b/pythonSoftIOC/4.0.2/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/reference/contributing.html
+++ b/pythonSoftIOC/4.0.2/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/search.html
+++ b/pythonSoftIOC/4.0.2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.0.2/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.0.2/tutorials/installation.html
+++ b/pythonSoftIOC/4.0.2/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.0.2/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.1.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/index.html
+++ b/pythonSoftIOC/4.1.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/4.1.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.1.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.1.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.1.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.1.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.1.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/genindex.html
+++ b/pythonSoftIOC/4.1.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.1.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.1.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.1.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.1.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/index.html
+++ b/pythonSoftIOC/4.1.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/py-modindex.html
+++ b/pythonSoftIOC/4.1.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/reference/api.html
+++ b/pythonSoftIOC/4.1.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/reference/contributing.html
+++ b/pythonSoftIOC/4.1.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/search.html
+++ b/pythonSoftIOC/4.1.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.1.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.1.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.1.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.1.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.2.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/index.html
+++ b/pythonSoftIOC/4.2.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/4.2.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.2.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.2.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.2.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.2.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.2.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/genindex.html
+++ b/pythonSoftIOC/4.2.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.2.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.2.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.2.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.2.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/index.html
+++ b/pythonSoftIOC/4.2.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/py-modindex.html
+++ b/pythonSoftIOC/4.2.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/reference/api.html
+++ b/pythonSoftIOC/4.2.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/reference/contributing.html
+++ b/pythonSoftIOC/4.2.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/search.html
+++ b/pythonSoftIOC/4.2.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.2.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.2.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.2.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.2.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.3.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/index.html
+++ b/pythonSoftIOC/4.3.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/4.3.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.3.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.3.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.3.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.3.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.3.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/genindex.html
+++ b/pythonSoftIOC/4.3.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.3.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.3.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.3.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.3.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/index.html
+++ b/pythonSoftIOC/4.3.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/py-modindex.html
+++ b/pythonSoftIOC/4.3.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/reference/api.html
+++ b/pythonSoftIOC/4.3.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/reference/contributing.html
+++ b/pythonSoftIOC/4.3.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/search.html
+++ b/pythonSoftIOC/4.3.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.3.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.3.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.3.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.3.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.4.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/index.html
+++ b/pythonSoftIOC/4.4.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/4.4.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.4.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.4.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.4.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.4.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.4.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/genindex.html
+++ b/pythonSoftIOC/4.4.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.4.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.4.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.4.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.4.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/index.html
+++ b/pythonSoftIOC/4.4.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/py-modindex.html
+++ b/pythonSoftIOC/4.4.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/reference/api.html
+++ b/pythonSoftIOC/4.4.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/reference/contributing.html
+++ b/pythonSoftIOC/4.4.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/search.html
+++ b/pythonSoftIOC/4.4.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.4.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.4.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.4.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.4.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/4.5.0/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/index.html
+++ b/pythonSoftIOC/4.5.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/4.5.0/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/softioc/builder.html
+++ b/pythonSoftIOC/4.5.0/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/softioc/device.html
+++ b/pythonSoftIOC/4.5.0/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/4.5.0/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/4.5.0/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/4.5.0/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/genindex.html
+++ b/pythonSoftIOC/4.5.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/4.5.0/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/4.5.0/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/4.5.0/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/how-to/use-soft-records.html
+++ b/pythonSoftIOC/4.5.0/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/index.html
+++ b/pythonSoftIOC/4.5.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/py-modindex.html
+++ b/pythonSoftIOC/4.5.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/reference/api.html
+++ b/pythonSoftIOC/4.5.0/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/reference/contributing.html
+++ b/pythonSoftIOC/4.5.0/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/search.html
+++ b/pythonSoftIOC/4.5.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/4.5.0/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/4.5.0/tutorials/installation.html
+++ b/pythonSoftIOC/4.5.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/4.5.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pythonSoftIOC/index.html
+++ b/pythonSoftIOC/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/epicsdbbuilder/recordbase.html
+++ b/pythonSoftIOC/master/_modules/epicsdbbuilder/recordbase.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/epicsdbbuilder/recordbase.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/epicsdbbuilder/recordbase.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/epicsdbbuilder/recordbase.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/index.html
+++ b/pythonSoftIOC/master/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/softioc/asyncio_dispatcher.html
+++ b/pythonSoftIOC/master/_modules/softioc/asyncio_dispatcher.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/asyncio_dispatcher.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/asyncio_dispatcher.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/asyncio_dispatcher.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/softioc/builder.html
+++ b/pythonSoftIOC/master/_modules/softioc/builder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/builder.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/builder.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/builder.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/softioc/device.html
+++ b/pythonSoftIOC/master/_modules/softioc/device.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/device.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/device.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/device.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/_modules/softioc/softioc.html
+++ b/pythonSoftIOC/master/_modules/softioc/softioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/softioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/softioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/_modules/softioc/softioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/explanations/asyncio-cothread-differences.html
+++ b/pythonSoftIOC/master/explanations/asyncio-cothread-differences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/explanations/asyncio-cothread-differences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/explanations/asyncio-cothread-differences.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/explanations/asyncio-cothread-differences.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/explanations/why-use-pythonIoc.html
+++ b/pythonSoftIOC/master/explanations/why-use-pythonIoc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonIoc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonIoc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonIoc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/explanations/why-use-pythonSoftIOC.html
+++ b/pythonSoftIOC/master/explanations/why-use-pythonSoftIOC.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonSoftIOC.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonSoftIOC.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/explanations/why-use-pythonSoftIOC.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/genindex.html
+++ b/pythonSoftIOC/master/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/genindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/genindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/how-to/make-publishable-ioc.html
+++ b/pythonSoftIOC/master/how-to/make-publishable-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/how-to/make-publishable-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/how-to/make-publishable-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/how-to/make-publishable-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/how-to/read-data-from-ioc.html
+++ b/pythonSoftIOC/master/how-to/read-data-from-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/how-to/read-data-from-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/how-to/read-data-from-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/how-to/read-data-from-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/how-to/use-asyncio-in-an-ioc.html
+++ b/pythonSoftIOC/master/how-to/use-asyncio-in-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/how-to/use-asyncio-in-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/how-to/use-asyncio-in-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/how-to/use-asyncio-in-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/how-to/use-soft-records.html
+++ b/pythonSoftIOC/master/how-to/use-soft-records.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/how-to/use-soft-records.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/how-to/use-soft-records.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/how-to/use-soft-records.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/index.html
+++ b/pythonSoftIOC/master/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/index.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/index.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/py-modindex.html
+++ b/pythonSoftIOC/master/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/py-modindex.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/py-modindex.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/reference/api.html
+++ b/pythonSoftIOC/master/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/reference/api.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/reference/api.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/reference/changelog.html
+++ b/pythonSoftIOC/master/reference/changelog.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/reference/changelog.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/reference/changelog.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/reference/changelog.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/reference/contributing.html
+++ b/pythonSoftIOC/master/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/reference/contributing.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/reference/contributing.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/search.html
+++ b/pythonSoftIOC/master/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/search.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/search.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/tutorials/creating-an-ioc.html
+++ b/pythonSoftIOC/master/tutorials/creating-an-ioc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/tutorials/creating-an-ioc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/tutorials/creating-an-ioc.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/tutorials/creating-an-ioc.html">
+  </head>
+</html>

--- a/pythonSoftIOC/master/tutorials/installation.html
+++ b/pythonSoftIOC/master/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://epics-python.github.io/pythonSoftIOC/master/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://epics-python.github.io/pythonSoftIOC/master/tutorials/installation.html">
+    <link rel="canonical" href="https://epics-python.github.io/pythonSoftIOC/master/tutorials/installation.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/pythonSoftIOC` using https://gitlab.diamond.ac.uk/github/github-scripts