### PR TITLE
Added redirects for tristan-detector

### DIFF
--- a/tristan-detector/docs/genindex.html
+++ b/tristan-detector/docs/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/genindex.html">
+  </head>
+</html>

--- a/tristan-detector/docs/index.html
+++ b/tristan-detector/docs/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/index.html">
+  </head>
+</html>

--- a/tristan-detector/docs/installation.html
+++ b/tristan-detector/docs/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/installation.html">
+  </head>
+</html>

--- a/tristan-detector/docs/introduction.html
+++ b/tristan-detector/docs/introduction.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/introduction.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/introduction.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/introduction.html">
+  </head>
+</html>

--- a/tristan-detector/docs/search.html
+++ b/tristan-detector/docs/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/search.html">
+  </head>
+</html>

--- a/tristan-detector/docs/setup.html
+++ b/tristan-detector/docs/setup.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/setup.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/setup.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/setup.html">
+  </head>
+</html>

--- a/tristan-detector/docs/userguide.html
+++ b/tristan-detector/docs/userguide.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/docs/userguide.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/docs/userguide.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/docs/userguide.html">
+  </head>
+</html>

--- a/tristan-detector/index.html
+++ b/tristan-detector/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tristan-detector/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tristan-detector/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tristan-detector/index.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/tristan-detector` using https://gitlab.diamond.ac.uk/github/github-scripts