### PR TITLE
Added redirects for sphinx-graphql

### DIFF
--- a/sphinx-graphql/0.1.1-pre1/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.1-pre1/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/genindex.html
+++ b/sphinx-graphql/0.1.1-pre1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.1-pre1/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/index.html
+++ b/sphinx-graphql/0.1.1-pre1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/reference/api.html
+++ b/sphinx-graphql/0.1.1-pre1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/reference/contributing.html
+++ b/sphinx-graphql/0.1.1-pre1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/search.html
+++ b/sphinx-graphql/0.1.1-pre1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre1/tutorials/installation.html
+++ b/sphinx-graphql/0.1.1-pre1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre1/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.1-pre2/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/genindex.html
+++ b/sphinx-graphql/0.1.1-pre2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.1-pre2/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/index.html
+++ b/sphinx-graphql/0.1.1-pre2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/reference/api.html
+++ b/sphinx-graphql/0.1.1-pre2/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/reference/contributing.html
+++ b/sphinx-graphql/0.1.1-pre2/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/search.html
+++ b/sphinx-graphql/0.1.1-pre2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre2/tutorials/installation.html
+++ b/sphinx-graphql/0.1.1-pre2/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre2/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.1-pre3/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/genindex.html
+++ b/sphinx-graphql/0.1.1-pre3/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.1-pre3/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/index.html
+++ b/sphinx-graphql/0.1.1-pre3/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/reference/api.html
+++ b/sphinx-graphql/0.1.1-pre3/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/reference/contributing.html
+++ b/sphinx-graphql/0.1.1-pre3/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/search.html
+++ b/sphinx-graphql/0.1.1-pre3/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1-pre3/tutorials/installation.html
+++ b/sphinx-graphql/0.1.1-pre3/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1-pre3/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.1/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/genindex.html
+++ b/sphinx-graphql/0.1.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.1/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/index.html
+++ b/sphinx-graphql/0.1.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/reference/api.html
+++ b/sphinx-graphql/0.1.1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/reference/contributing.html
+++ b/sphinx-graphql/0.1.1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/search.html
+++ b/sphinx-graphql/0.1.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.1/tutorials/installation.html
+++ b/sphinx-graphql/0.1.1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.1/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.1/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.2-pre1/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/genindex.html
+++ b/sphinx-graphql/0.1.2-pre1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.2-pre1/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/index.html
+++ b/sphinx-graphql/0.1.2-pre1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/reference/api.html
+++ b/sphinx-graphql/0.1.2-pre1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/reference/contributing.html
+++ b/sphinx-graphql/0.1.2-pre1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/search.html
+++ b/sphinx-graphql/0.1.2-pre1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2-pre1/tutorials/installation.html
+++ b/sphinx-graphql/0.1.2-pre1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2-pre1/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1.2/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/genindex.html
+++ b/sphinx-graphql/0.1.2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1.2/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/index.html
+++ b/sphinx-graphql/0.1.2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/reference/api.html
+++ b/sphinx-graphql/0.1.2/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/reference/contributing.html
+++ b/sphinx-graphql/0.1.2/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/search.html
+++ b/sphinx-graphql/0.1.2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1.2/tutorials/installation.html
+++ b/sphinx-graphql/0.1.2/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1.2/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1.2/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1.2/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/explanations/why-is-something-so.html
+++ b/sphinx-graphql/0.1/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/genindex.html
+++ b/sphinx-graphql/0.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/how-to/embed-graphiql.html
+++ b/sphinx-graphql/0.1/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/index.html
+++ b/sphinx-graphql/0.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/reference/api.html
+++ b/sphinx-graphql/0.1/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/reference/contributing.html
+++ b/sphinx-graphql/0.1/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/search.html
+++ b/sphinx-graphql/0.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/0.1/tutorials/installation.html
+++ b/sphinx-graphql/0.1/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/0.1/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/0.1/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/0.1/tutorials/installation.html">
+  </head>
+</html>

--- a/sphinx-graphql/index.html
+++ b/sphinx-graphql/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/explanations/why-is-something-so.html
+++ b/sphinx-graphql/master/explanations/why-is-something-so.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/explanations/why-is-something-so.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/explanations/why-is-something-so.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/explanations/why-is-something-so.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/genindex.html
+++ b/sphinx-graphql/master/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/genindex.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/how-to/accomplish-a-task.html
+++ b/sphinx-graphql/master/how-to/accomplish-a-task.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/how-to/accomplish-a-task.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/how-to/accomplish-a-task.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/how-to/accomplish-a-task.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/how-to/embed-graphiql.html
+++ b/sphinx-graphql/master/how-to/embed-graphiql.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/how-to/embed-graphiql.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/how-to/embed-graphiql.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/how-to/embed-graphiql.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/index.html
+++ b/sphinx-graphql/master/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/index.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/reference/api.html
+++ b/sphinx-graphql/master/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/reference/api.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/reference/contributing.html
+++ b/sphinx-graphql/master/reference/contributing.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/reference/contributing.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/reference/contributing.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/reference/contributing.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/search.html
+++ b/sphinx-graphql/master/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/search.html">
+  </head>
+</html>

--- a/sphinx-graphql/master/tutorials/installation.html
+++ b/sphinx-graphql/master/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/sphinx-graphql/master/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/sphinx-graphql/master/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/sphinx-graphql/master/tutorials/installation.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/sphinx-graphql` using https://gitlab.diamond.ac.uk/github/github-scripts