### PR TITLE
Added redirects for pmac_motorhome

### DIFF
--- a/pmac_motorhome/0.5/_modules/index.html
+++ b/pmac_motorhome/0.5/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/0.5/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/explanations/epics.html
+++ b/pmac_motorhome/0.5/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/explanations/history.html
+++ b/pmac_motorhome/0.5/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/explanations/implementation.html
+++ b/pmac_motorhome/0.5/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/genindex.html
+++ b/pmac_motorhome/0.5/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/how-to/modifying.html
+++ b/pmac_motorhome/0.5/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/index.html
+++ b/pmac_motorhome/0.5/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/py-modindex.html
+++ b/pmac_motorhome/0.5/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/commands.html
+++ b/pmac_motorhome/0.5/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/constants.html
+++ b/pmac_motorhome/0.5/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/external.html
+++ b/pmac_motorhome/0.5/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/internal.html
+++ b/pmac_motorhome/0.5/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/overview.html
+++ b/pmac_motorhome/0.5/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/sequences.html
+++ b/pmac_motorhome/0.5/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/reference/snippets.html
+++ b/pmac_motorhome/0.5/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/search.html
+++ b/pmac_motorhome/0.5/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/tutorials/converting.html
+++ b/pmac_motorhome/0.5/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/tutorials/custom.html
+++ b/pmac_motorhome/0.5/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/tutorials/example.html
+++ b/pmac_motorhome/0.5/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/0.5/tutorials/installation.html
+++ b/pmac_motorhome/0.5/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/0.5/tutorials/installation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/index.html
+++ b/pmac_motorhome/1.0/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/1.0/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/explanations/epics.html
+++ b/pmac_motorhome/1.0/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/explanations/history.html
+++ b/pmac_motorhome/1.0/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/explanations/implementation.html
+++ b/pmac_motorhome/1.0/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/genindex.html
+++ b/pmac_motorhome/1.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/how-to/modifying.html
+++ b/pmac_motorhome/1.0/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/index.html
+++ b/pmac_motorhome/1.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/py-modindex.html
+++ b/pmac_motorhome/1.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/commands.html
+++ b/pmac_motorhome/1.0/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/constants.html
+++ b/pmac_motorhome/1.0/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/external.html
+++ b/pmac_motorhome/1.0/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/internal.html
+++ b/pmac_motorhome/1.0/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/overview.html
+++ b/pmac_motorhome/1.0/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/sequences.html
+++ b/pmac_motorhome/1.0/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/reference/snippets.html
+++ b/pmac_motorhome/1.0/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/search.html
+++ b/pmac_motorhome/1.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/tutorials/converting.html
+++ b/pmac_motorhome/1.0/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/tutorials/custom.html
+++ b/pmac_motorhome/1.0/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/tutorials/example.html
+++ b/pmac_motorhome/1.0/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.0/tutorials/installation.html
+++ b/pmac_motorhome/1.0/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.0/tutorials/installation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/index.html
+++ b/pmac_motorhome/1.5/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/1.5/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/explanations/epics.html
+++ b/pmac_motorhome/1.5/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/explanations/history.html
+++ b/pmac_motorhome/1.5/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/explanations/implementation.html
+++ b/pmac_motorhome/1.5/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/genindex.html
+++ b/pmac_motorhome/1.5/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/how-to/modifying.html
+++ b/pmac_motorhome/1.5/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/index.html
+++ b/pmac_motorhome/1.5/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/py-modindex.html
+++ b/pmac_motorhome/1.5/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/commands.html
+++ b/pmac_motorhome/1.5/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/constants.html
+++ b/pmac_motorhome/1.5/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/external.html
+++ b/pmac_motorhome/1.5/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/internal.html
+++ b/pmac_motorhome/1.5/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/overview.html
+++ b/pmac_motorhome/1.5/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/sequences.html
+++ b/pmac_motorhome/1.5/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/reference/snippets.html
+++ b/pmac_motorhome/1.5/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/search.html
+++ b/pmac_motorhome/1.5/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/tutorials/converting.html
+++ b/pmac_motorhome/1.5/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/tutorials/custom.html
+++ b/pmac_motorhome/1.5/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/tutorials/example.html
+++ b/pmac_motorhome/1.5/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.5/tutorials/installation.html
+++ b/pmac_motorhome/1.5/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.5/tutorials/installation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/index.html
+++ b/pmac_motorhome/1.6/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/1.6/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/explanations/epics.html
+++ b/pmac_motorhome/1.6/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/explanations/history.html
+++ b/pmac_motorhome/1.6/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/explanations/implementation.html
+++ b/pmac_motorhome/1.6/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/genindex.html
+++ b/pmac_motorhome/1.6/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/how-to/modifying.html
+++ b/pmac_motorhome/1.6/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/index.html
+++ b/pmac_motorhome/1.6/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/py-modindex.html
+++ b/pmac_motorhome/1.6/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/commands.html
+++ b/pmac_motorhome/1.6/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/constants.html
+++ b/pmac_motorhome/1.6/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/external.html
+++ b/pmac_motorhome/1.6/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/internal.html
+++ b/pmac_motorhome/1.6/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/overview.html
+++ b/pmac_motorhome/1.6/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/sequences.html
+++ b/pmac_motorhome/1.6/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/reference/snippets.html
+++ b/pmac_motorhome/1.6/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/search.html
+++ b/pmac_motorhome/1.6/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/tutorials/converting.html
+++ b/pmac_motorhome/1.6/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/tutorials/custom.html
+++ b/pmac_motorhome/1.6/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/tutorials/example.html
+++ b/pmac_motorhome/1.6/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.6/tutorials/installation.html
+++ b/pmac_motorhome/1.6/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.6/tutorials/installation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/index.html
+++ b/pmac_motorhome/1.7/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/1.7/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/explanations/epics.html
+++ b/pmac_motorhome/1.7/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/explanations/history.html
+++ b/pmac_motorhome/1.7/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/explanations/implementation.html
+++ b/pmac_motorhome/1.7/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/genindex.html
+++ b/pmac_motorhome/1.7/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/how-to/modifying.html
+++ b/pmac_motorhome/1.7/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/index.html
+++ b/pmac_motorhome/1.7/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/py-modindex.html
+++ b/pmac_motorhome/1.7/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/commands.html
+++ b/pmac_motorhome/1.7/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/constants.html
+++ b/pmac_motorhome/1.7/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/external.html
+++ b/pmac_motorhome/1.7/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/internal.html
+++ b/pmac_motorhome/1.7/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/overview.html
+++ b/pmac_motorhome/1.7/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/sequences.html
+++ b/pmac_motorhome/1.7/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/reference/snippets.html
+++ b/pmac_motorhome/1.7/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/search.html
+++ b/pmac_motorhome/1.7/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/tutorials/converting.html
+++ b/pmac_motorhome/1.7/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/tutorials/custom.html
+++ b/pmac_motorhome/1.7/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/tutorials/example.html
+++ b/pmac_motorhome/1.7/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/1.7/tutorials/installation.html
+++ b/pmac_motorhome/1.7/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/1.7/tutorials/installation.html">
+  </head>
+</html>

--- a/pmac_motorhome/index.html
+++ b/pmac_motorhome/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/index.html
+++ b/pmac_motorhome/master/_modules/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/commands.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/constants.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/group.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/group.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/group.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/group.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/group.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/motor.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/motor.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/motor.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/motor.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/motor.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/onlyaxes.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/onlyaxes.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/onlyaxes.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/onlyaxes.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/onlyaxes.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/plc.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/plc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/plc.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/plc.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/plc.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/sequences.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/snippets.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/_modules/pmac_motorhome/template.html
+++ b/pmac_motorhome/master/_modules/pmac_motorhome/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/template.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/template.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/_modules/pmac_motorhome/template.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/explanations/epics.html
+++ b/pmac_motorhome/master/explanations/epics.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/explanations/epics.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/explanations/epics.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/explanations/epics.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/explanations/history.html
+++ b/pmac_motorhome/master/explanations/history.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/explanations/history.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/explanations/history.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/explanations/history.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/explanations/implementation.html
+++ b/pmac_motorhome/master/explanations/implementation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/explanations/implementation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/explanations/implementation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/explanations/implementation.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/genindex.html
+++ b/pmac_motorhome/master/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/genindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/how-to/modifying.html
+++ b/pmac_motorhome/master/how-to/modifying.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/how-to/modifying.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/how-to/modifying.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/how-to/modifying.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/index.html
+++ b/pmac_motorhome/master/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/index.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/py-modindex.html
+++ b/pmac_motorhome/master/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/py-modindex.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/commands.html
+++ b/pmac_motorhome/master/reference/commands.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/commands.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/commands.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/commands.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/constants.html
+++ b/pmac_motorhome/master/reference/constants.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/constants.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/constants.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/constants.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/external.html
+++ b/pmac_motorhome/master/reference/external.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/external.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/external.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/external.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/internal.html
+++ b/pmac_motorhome/master/reference/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/internal.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/internal.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/internal.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/overview.html
+++ b/pmac_motorhome/master/reference/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/overview.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/sequences.html
+++ b/pmac_motorhome/master/reference/sequences.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/sequences.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/sequences.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/sequences.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/reference/snippets.html
+++ b/pmac_motorhome/master/reference/snippets.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/reference/snippets.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/reference/snippets.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/reference/snippets.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/search.html
+++ b/pmac_motorhome/master/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/search.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/tutorials/converting.html
+++ b/pmac_motorhome/master/tutorials/converting.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/converting.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/converting.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/converting.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/tutorials/custom.html
+++ b/pmac_motorhome/master/tutorials/custom.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/custom.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/custom.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/custom.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/tutorials/example.html
+++ b/pmac_motorhome/master/tutorials/example.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/example.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/example.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/example.html">
+  </head>
+</html>

--- a/pmac_motorhome/master/tutorials/installation.html
+++ b/pmac_motorhome/master/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmac_motorhome/master/tutorials/installation.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/pmac_motorhome` using https://gitlab.diamond.ac.uk/github/github-scripts