### PR TITLE
Added redirects for tickit-devices

### DIFF
--- a/tickit-devices/0.1.0/_static/webpack-macros.html
+++ b/tickit-devices/0.1.0/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/explanations/decisions.html
+++ b/tickit-devices/0.1.0/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/0.1.0/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/0.1.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/build-docs.html
+++ b/tickit-devices/0.1.0/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/contribute.html
+++ b/tickit-devices/0.1.0/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/lint.html
+++ b/tickit-devices/0.1.0/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/make-release.html
+++ b/tickit-devices/0.1.0/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/pin-requirements.html
+++ b/tickit-devices/0.1.0/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/run-tests.html
+++ b/tickit-devices/0.1.0/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/static-analysis.html
+++ b/tickit-devices/0.1.0/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/test-container.html
+++ b/tickit-devices/0.1.0/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/how-to/update-tools.html
+++ b/tickit-devices/0.1.0/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/index.html
+++ b/tickit-devices/0.1.0/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/reference/standards.html
+++ b/tickit-devices/0.1.0/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/developer/tutorials/dev-install.html
+++ b/tickit-devices/0.1.0/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/genindex.html
+++ b/tickit-devices/0.1.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/index.html
+++ b/tickit-devices/0.1.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/py-modindex.html
+++ b/tickit-devices/0.1.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/search.html
+++ b/tickit-devices/0.1.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/search.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/user/explanations/docs-structure.html
+++ b/tickit-devices/0.1.0/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/user/how-to/run-container.html
+++ b/tickit-devices/0.1.0/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/user/index.html
+++ b/tickit-devices/0.1.0/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/user/reference/api.html
+++ b/tickit-devices/0.1.0/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/0.1.0/user/tutorials/installation.html
+++ b/tickit-devices/0.1.0/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.1.0/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.1.0/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.1.0/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/_static/webpack-macros.html
+++ b/tickit-devices/0.2.0/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/explanations/decisions.html
+++ b/tickit-devices/0.2.0/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/0.2.0/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/0.2.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/build-docs.html
+++ b/tickit-devices/0.2.0/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/contribute.html
+++ b/tickit-devices/0.2.0/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/lint.html
+++ b/tickit-devices/0.2.0/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/make-release.html
+++ b/tickit-devices/0.2.0/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/pin-requirements.html
+++ b/tickit-devices/0.2.0/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/run-tests.html
+++ b/tickit-devices/0.2.0/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/static-analysis.html
+++ b/tickit-devices/0.2.0/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/test-container.html
+++ b/tickit-devices/0.2.0/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/how-to/update-tools.html
+++ b/tickit-devices/0.2.0/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/index.html
+++ b/tickit-devices/0.2.0/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/reference/standards.html
+++ b/tickit-devices/0.2.0/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/developer/tutorials/dev-install.html
+++ b/tickit-devices/0.2.0/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/genindex.html
+++ b/tickit-devices/0.2.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/index.html
+++ b/tickit-devices/0.2.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/py-modindex.html
+++ b/tickit-devices/0.2.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/search.html
+++ b/tickit-devices/0.2.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/search.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/user/explanations/docs-structure.html
+++ b/tickit-devices/0.2.0/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/user/how-to/run-container.html
+++ b/tickit-devices/0.2.0/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/user/index.html
+++ b/tickit-devices/0.2.0/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/user/reference/api.html
+++ b/tickit-devices/0.2.0/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/0.2.0/user/tutorials/installation.html
+++ b/tickit-devices/0.2.0/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.2.0/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.2.0/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.2.0/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/_static/webpack-macros.html
+++ b/tickit-devices/0.3.0/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/explanations/decisions.html
+++ b/tickit-devices/0.3.0/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/0.3.0/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/0.3.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/build-docs.html
+++ b/tickit-devices/0.3.0/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/contribute.html
+++ b/tickit-devices/0.3.0/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/lint.html
+++ b/tickit-devices/0.3.0/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/make-release.html
+++ b/tickit-devices/0.3.0/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/pin-requirements.html
+++ b/tickit-devices/0.3.0/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/run-tests.html
+++ b/tickit-devices/0.3.0/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/static-analysis.html
+++ b/tickit-devices/0.3.0/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/test-container.html
+++ b/tickit-devices/0.3.0/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/how-to/update-tools.html
+++ b/tickit-devices/0.3.0/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/index.html
+++ b/tickit-devices/0.3.0/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/reference/standards.html
+++ b/tickit-devices/0.3.0/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/developer/tutorials/dev-install.html
+++ b/tickit-devices/0.3.0/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/genindex.html
+++ b/tickit-devices/0.3.0/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/index.html
+++ b/tickit-devices/0.3.0/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/py-modindex.html
+++ b/tickit-devices/0.3.0/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/search.html
+++ b/tickit-devices/0.3.0/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/search.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/user/explanations/docs-structure.html
+++ b/tickit-devices/0.3.0/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/user/how-to/run-container.html
+++ b/tickit-devices/0.3.0/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/user/index.html
+++ b/tickit-devices/0.3.0/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/user/reference/api.html
+++ b/tickit-devices/0.3.0/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.0/user/tutorials/installation.html
+++ b/tickit-devices/0.3.0/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.0/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.0/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.0/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/_static/webpack-macros.html
+++ b/tickit-devices/0.3.1/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/explanations/decisions.html
+++ b/tickit-devices/0.3.1/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/0.3.1/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/0.3.1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/build-docs.html
+++ b/tickit-devices/0.3.1/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/contribute.html
+++ b/tickit-devices/0.3.1/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/lint.html
+++ b/tickit-devices/0.3.1/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/make-release.html
+++ b/tickit-devices/0.3.1/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/pin-requirements.html
+++ b/tickit-devices/0.3.1/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/run-tests.html
+++ b/tickit-devices/0.3.1/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/static-analysis.html
+++ b/tickit-devices/0.3.1/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/test-container.html
+++ b/tickit-devices/0.3.1/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/how-to/update-tools.html
+++ b/tickit-devices/0.3.1/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/index.html
+++ b/tickit-devices/0.3.1/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/reference/standards.html
+++ b/tickit-devices/0.3.1/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/developer/tutorials/dev-install.html
+++ b/tickit-devices/0.3.1/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/genindex.html
+++ b/tickit-devices/0.3.1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/index.html
+++ b/tickit-devices/0.3.1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/py-modindex.html
+++ b/tickit-devices/0.3.1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/search.html
+++ b/tickit-devices/0.3.1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/search.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/user/explanations/docs-structure.html
+++ b/tickit-devices/0.3.1/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/user/how-to/run-container.html
+++ b/tickit-devices/0.3.1/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/user/index.html
+++ b/tickit-devices/0.3.1/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/user/reference/api.html
+++ b/tickit-devices/0.3.1/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/0.3.1/user/tutorials/installation.html
+++ b/tickit-devices/0.3.1/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/0.3.1/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/0.3.1/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/0.3.1/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/_static/webpack-macros.html
+++ b/tickit-devices/DiamondJoseph-patch-1/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/build-docs.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/contribute.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/lint.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/make-release.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/pin-requirements.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/run-tests.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/static-analysis.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/test-container.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/how-to/update-tools.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/index.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/reference/standards.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/developer/tutorials/dev-install.html
+++ b/tickit-devices/DiamondJoseph-patch-1/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/genindex.html
+++ b/tickit-devices/DiamondJoseph-patch-1/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/index.html
+++ b/tickit-devices/DiamondJoseph-patch-1/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/index.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/py-modindex.html
+++ b/tickit-devices/DiamondJoseph-patch-1/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/search.html
+++ b/tickit-devices/DiamondJoseph-patch-1/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/search.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/user/explanations/docs-structure.html
+++ b/tickit-devices/DiamondJoseph-patch-1/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/user/how-to/run-container.html
+++ b/tickit-devices/DiamondJoseph-patch-1/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/user/index.html
+++ b/tickit-devices/DiamondJoseph-patch-1/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/user/reference/api.html
+++ b/tickit-devices/DiamondJoseph-patch-1/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/DiamondJoseph-patch-1/user/tutorials/installation.html
+++ b/tickit-devices/DiamondJoseph-patch-1/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/DiamondJoseph-patch-1/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/_static/webpack-macros.html
+++ b/tickit-devices/debug-configurations/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/explanations/decisions.html
+++ b/tickit-devices/debug-configurations/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/debug-configurations/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/debug-configurations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/build-docs.html
+++ b/tickit-devices/debug-configurations/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/contribute.html
+++ b/tickit-devices/debug-configurations/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/lint.html
+++ b/tickit-devices/debug-configurations/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/make-release.html
+++ b/tickit-devices/debug-configurations/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/pin-requirements.html
+++ b/tickit-devices/debug-configurations/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/run-tests.html
+++ b/tickit-devices/debug-configurations/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/static-analysis.html
+++ b/tickit-devices/debug-configurations/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/test-container.html
+++ b/tickit-devices/debug-configurations/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/how-to/update-tools.html
+++ b/tickit-devices/debug-configurations/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/index.html
+++ b/tickit-devices/debug-configurations/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/reference/standards.html
+++ b/tickit-devices/debug-configurations/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/developer/tutorials/dev-install.html
+++ b/tickit-devices/debug-configurations/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/genindex.html
+++ b/tickit-devices/debug-configurations/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/index.html
+++ b/tickit-devices/debug-configurations/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/index.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/py-modindex.html
+++ b/tickit-devices/debug-configurations/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/search.html
+++ b/tickit-devices/debug-configurations/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/search.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/user/explanations/docs-structure.html
+++ b/tickit-devices/debug-configurations/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/user/how-to/run-container.html
+++ b/tickit-devices/debug-configurations/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/user/index.html
+++ b/tickit-devices/debug-configurations/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/user/reference/api.html
+++ b/tickit-devices/debug-configurations/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/debug-configurations/user/tutorials/installation.html
+++ b/tickit-devices/debug-configurations/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/debug-configurations/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/_static/webpack-macros.html
+++ b/tickit-devices/eiger-stream2-backup/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/explanations/decisions.html
+++ b/tickit-devices/eiger-stream2-backup/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/build-docs.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/contribute.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/lint.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/make-release.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/pin-requirements.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/run-tests.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/static-analysis.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/test-container.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/how-to/update-tools.html
+++ b/tickit-devices/eiger-stream2-backup/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/index.html
+++ b/tickit-devices/eiger-stream2-backup/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/reference/standards.html
+++ b/tickit-devices/eiger-stream2-backup/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/developer/tutorials/dev-install.html
+++ b/tickit-devices/eiger-stream2-backup/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/genindex.html
+++ b/tickit-devices/eiger-stream2-backup/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/index.html
+++ b/tickit-devices/eiger-stream2-backup/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/py-modindex.html
+++ b/tickit-devices/eiger-stream2-backup/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/search.html
+++ b/tickit-devices/eiger-stream2-backup/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/search.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/user/explanations/docs-structure.html
+++ b/tickit-devices/eiger-stream2-backup/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/user/how-to/run-container.html
+++ b/tickit-devices/eiger-stream2-backup/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/user/index.html
+++ b/tickit-devices/eiger-stream2-backup/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/user/reference/api.html
+++ b/tickit-devices/eiger-stream2-backup/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2-backup/user/tutorials/installation.html
+++ b/tickit-devices/eiger-stream2-backup/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2-backup/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/_static/webpack-macros.html
+++ b/tickit-devices/eiger-stream2/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/explanations/decisions.html
+++ b/tickit-devices/eiger-stream2/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/eiger-stream2/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/eiger-stream2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/build-docs.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/contribute.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/lint.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/make-release.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/pin-requirements.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/run-tests.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/static-analysis.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/test-container.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/how-to/update-tools.html
+++ b/tickit-devices/eiger-stream2/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/index.html
+++ b/tickit-devices/eiger-stream2/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/reference/standards.html
+++ b/tickit-devices/eiger-stream2/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/developer/tutorials/dev-install.html
+++ b/tickit-devices/eiger-stream2/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/genindex.html
+++ b/tickit-devices/eiger-stream2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/index.html
+++ b/tickit-devices/eiger-stream2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/py-modindex.html
+++ b/tickit-devices/eiger-stream2/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/search.html
+++ b/tickit-devices/eiger-stream2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/search.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/user/explanations/docs-structure.html
+++ b/tickit-devices/eiger-stream2/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/user/how-to/run-container.html
+++ b/tickit-devices/eiger-stream2/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/user/index.html
+++ b/tickit-devices/eiger-stream2/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/user/reference/api.html
+++ b/tickit-devices/eiger-stream2/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/eiger-stream2/user/tutorials/installation.html
+++ b/tickit-devices/eiger-stream2/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/eiger-stream2/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/_static/webpack-macros.html
+++ b/tickit-devices/enum_type_annotations/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/explanations/decisions.html
+++ b/tickit-devices/enum_type_annotations/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/enum_type_annotations/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/enum_type_annotations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/build-docs.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/contribute.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/lint.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/make-release.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/pin-requirements.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/run-tests.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/static-analysis.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/test-container.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/how-to/update-tools.html
+++ b/tickit-devices/enum_type_annotations/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/index.html
+++ b/tickit-devices/enum_type_annotations/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/reference/standards.html
+++ b/tickit-devices/enum_type_annotations/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/developer/tutorials/dev-install.html
+++ b/tickit-devices/enum_type_annotations/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/genindex.html
+++ b/tickit-devices/enum_type_annotations/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/index.html
+++ b/tickit-devices/enum_type_annotations/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/index.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/py-modindex.html
+++ b/tickit-devices/enum_type_annotations/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/search.html
+++ b/tickit-devices/enum_type_annotations/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/search.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/user/explanations/docs-structure.html
+++ b/tickit-devices/enum_type_annotations/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/user/how-to/run-container.html
+++ b/tickit-devices/enum_type_annotations/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/user/index.html
+++ b/tickit-devices/enum_type_annotations/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/user/reference/api.html
+++ b/tickit-devices/enum_type_annotations/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/enum_type_annotations/user/tutorials/installation.html
+++ b/tickit-devices/enum_type_annotations/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/enum_type_annotations/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/_static/webpack-macros.html
+++ b/tickit-devices/fix-eiger-stream/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/explanations/decisions.html
+++ b/tickit-devices/fix-eiger-stream/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/build-docs.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/contribute.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/lint.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/make-release.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/pin-requirements.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/run-tests.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/static-analysis.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/test-container.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/how-to/update-tools.html
+++ b/tickit-devices/fix-eiger-stream/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/index.html
+++ b/tickit-devices/fix-eiger-stream/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/reference/standards.html
+++ b/tickit-devices/fix-eiger-stream/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/developer/tutorials/dev-install.html
+++ b/tickit-devices/fix-eiger-stream/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/genindex.html
+++ b/tickit-devices/fix-eiger-stream/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/index.html
+++ b/tickit-devices/fix-eiger-stream/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/py-modindex.html
+++ b/tickit-devices/fix-eiger-stream/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/search.html
+++ b/tickit-devices/fix-eiger-stream/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/search.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/user/explanations/docs-structure.html
+++ b/tickit-devices/fix-eiger-stream/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/user/how-to/run-container.html
+++ b/tickit-devices/fix-eiger-stream/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/user/index.html
+++ b/tickit-devices/fix-eiger-stream/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/user/reference/api.html
+++ b/tickit-devices/fix-eiger-stream/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/fix-eiger-stream/user/tutorials/installation.html
+++ b/tickit-devices/fix-eiger-stream/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-eiger-stream/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/_static/webpack-macros.html
+++ b/tickit-devices/fix-formatting/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/explanations/decisions.html
+++ b/tickit-devices/fix-formatting/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/fix-formatting/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/fix-formatting/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/build-docs.html
+++ b/tickit-devices/fix-formatting/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/contribute.html
+++ b/tickit-devices/fix-formatting/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/lint.html
+++ b/tickit-devices/fix-formatting/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/make-release.html
+++ b/tickit-devices/fix-formatting/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/pin-requirements.html
+++ b/tickit-devices/fix-formatting/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/run-tests.html
+++ b/tickit-devices/fix-formatting/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/static-analysis.html
+++ b/tickit-devices/fix-formatting/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/test-container.html
+++ b/tickit-devices/fix-formatting/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/how-to/update-tools.html
+++ b/tickit-devices/fix-formatting/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/index.html
+++ b/tickit-devices/fix-formatting/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/reference/standards.html
+++ b/tickit-devices/fix-formatting/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/developer/tutorials/dev-install.html
+++ b/tickit-devices/fix-formatting/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/genindex.html
+++ b/tickit-devices/fix-formatting/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/index.html
+++ b/tickit-devices/fix-formatting/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/py-modindex.html
+++ b/tickit-devices/fix-formatting/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/search.html
+++ b/tickit-devices/fix-formatting/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/search.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/user/explanations/docs-structure.html
+++ b/tickit-devices/fix-formatting/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/user/how-to/run-container.html
+++ b/tickit-devices/fix-formatting/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/user/index.html
+++ b/tickit-devices/fix-formatting/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/user/reference/api.html
+++ b/tickit-devices/fix-formatting/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/fix-formatting/user/tutorials/installation.html
+++ b/tickit-devices/fix-formatting/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/fix-formatting/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/index.html
+++ b/tickit-devices/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/index.html">
+  </head>
+</html>

--- a/tickit-devices/main/_static/webpack-macros.html
+++ b/tickit-devices/main/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/explanations/decisions.html
+++ b/tickit-devices/main/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/main/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/main/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/build-docs.html
+++ b/tickit-devices/main/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/contribute.html
+++ b/tickit-devices/main/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/lint.html
+++ b/tickit-devices/main/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/make-release.html
+++ b/tickit-devices/main/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/pin-requirements.html
+++ b/tickit-devices/main/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/run-tests.html
+++ b/tickit-devices/main/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/static-analysis.html
+++ b/tickit-devices/main/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/test-container.html
+++ b/tickit-devices/main/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/how-to/update-tools.html
+++ b/tickit-devices/main/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/index.html
+++ b/tickit-devices/main/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/reference/standards.html
+++ b/tickit-devices/main/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/main/developer/tutorials/dev-install.html
+++ b/tickit-devices/main/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/main/genindex.html
+++ b/tickit-devices/main/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/main/index.html
+++ b/tickit-devices/main/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/index.html">
+  </head>
+</html>

--- a/tickit-devices/main/py-modindex.html
+++ b/tickit-devices/main/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/main/search.html
+++ b/tickit-devices/main/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/search.html">
+  </head>
+</html>

--- a/tickit-devices/main/user/explanations/docs-structure.html
+++ b/tickit-devices/main/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/main/user/how-to/run-container.html
+++ b/tickit-devices/main/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/main/user/index.html
+++ b/tickit-devices/main/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/main/user/reference/api.html
+++ b/tickit-devices/main/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/main/user/tutorials/installation.html
+++ b/tickit-devices/main/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/main/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/main/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/main/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/_static/webpack-macros.html
+++ b/tickit-devices/merlin/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/explanations/decisions.html
+++ b/tickit-devices/merlin/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/merlin/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/merlin/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/build-docs.html
+++ b/tickit-devices/merlin/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/contribute.html
+++ b/tickit-devices/merlin/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/lint.html
+++ b/tickit-devices/merlin/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/make-release.html
+++ b/tickit-devices/merlin/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/pin-requirements.html
+++ b/tickit-devices/merlin/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/run-tests.html
+++ b/tickit-devices/merlin/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/static-analysis.html
+++ b/tickit-devices/merlin/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/test-container.html
+++ b/tickit-devices/merlin/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/how-to/update-tools.html
+++ b/tickit-devices/merlin/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/index.html
+++ b/tickit-devices/merlin/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/reference/standards.html
+++ b/tickit-devices/merlin/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/developer/tutorials/dev-install.html
+++ b/tickit-devices/merlin/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/genindex.html
+++ b/tickit-devices/merlin/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/index.html
+++ b/tickit-devices/merlin/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/index.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/py-modindex.html
+++ b/tickit-devices/merlin/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/search.html
+++ b/tickit-devices/merlin/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/search.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/user/explanations/docs-structure.html
+++ b/tickit-devices/merlin/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/user/how-to/run-container.html
+++ b/tickit-devices/merlin/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/user/index.html
+++ b/tickit-devices/merlin/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/user/reference/api.html
+++ b/tickit-devices/merlin/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/merlin/user/tutorials/installation.html
+++ b/tickit-devices/merlin/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/merlin/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/merlin/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/merlin/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/_static/webpack-macros.html
+++ b/tickit-devices/pydantic-eiger/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/explanations/decisions.html
+++ b/tickit-devices/pydantic-eiger/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/pydantic-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/pydantic-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/build-docs.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/contribute.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/lint.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/make-release.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/pin-requirements.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/run-tests.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/static-analysis.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/test-container.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/how-to/update-tools.html
+++ b/tickit-devices/pydantic-eiger/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/index.html
+++ b/tickit-devices/pydantic-eiger/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/reference/standards.html
+++ b/tickit-devices/pydantic-eiger/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/developer/tutorials/dev-install.html
+++ b/tickit-devices/pydantic-eiger/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/genindex.html
+++ b/tickit-devices/pydantic-eiger/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/index.html
+++ b/tickit-devices/pydantic-eiger/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/py-modindex.html
+++ b/tickit-devices/pydantic-eiger/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/search.html
+++ b/tickit-devices/pydantic-eiger/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/search.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/user/explanations/docs-structure.html
+++ b/tickit-devices/pydantic-eiger/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/user/how-to/run-container.html
+++ b/tickit-devices/pydantic-eiger/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/user/index.html
+++ b/tickit-devices/pydantic-eiger/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/user/reference/api.html
+++ b/tickit-devices/pydantic-eiger/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger/user/tutorials/installation.html
+++ b/tickit-devices/pydantic-eiger/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/_static/webpack-macros.html
+++ b/tickit-devices/pydantic-eiger2/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/explanations/decisions.html
+++ b/tickit-devices/pydantic-eiger2/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/build-docs.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/contribute.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/lint.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/make-release.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/pin-requirements.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/run-tests.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/static-analysis.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/test-container.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/how-to/update-tools.html
+++ b/tickit-devices/pydantic-eiger2/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/index.html
+++ b/tickit-devices/pydantic-eiger2/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/reference/standards.html
+++ b/tickit-devices/pydantic-eiger2/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/developer/tutorials/dev-install.html
+++ b/tickit-devices/pydantic-eiger2/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/genindex.html
+++ b/tickit-devices/pydantic-eiger2/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/index.html
+++ b/tickit-devices/pydantic-eiger2/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/py-modindex.html
+++ b/tickit-devices/pydantic-eiger2/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/search.html
+++ b/tickit-devices/pydantic-eiger2/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/search.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/user/explanations/docs-structure.html
+++ b/tickit-devices/pydantic-eiger2/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/user/how-to/run-container.html
+++ b/tickit-devices/pydantic-eiger2/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/user/index.html
+++ b/tickit-devices/pydantic-eiger2/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/user/reference/api.html
+++ b/tickit-devices/pydantic-eiger2/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/pydantic-eiger2/user/tutorials/installation.html
+++ b/tickit-devices/pydantic-eiger2/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/pydantic-eiger2/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/_static/webpack-macros.html
+++ b/tickit-devices/rename-component/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/explanations/decisions.html
+++ b/tickit-devices/rename-component/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/rename-component/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/rename-component/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/build-docs.html
+++ b/tickit-devices/rename-component/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/contribute.html
+++ b/tickit-devices/rename-component/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/lint.html
+++ b/tickit-devices/rename-component/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/make-release.html
+++ b/tickit-devices/rename-component/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/pin-requirements.html
+++ b/tickit-devices/rename-component/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/run-tests.html
+++ b/tickit-devices/rename-component/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/static-analysis.html
+++ b/tickit-devices/rename-component/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/test-container.html
+++ b/tickit-devices/rename-component/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/how-to/update-tools.html
+++ b/tickit-devices/rename-component/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/index.html
+++ b/tickit-devices/rename-component/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/reference/standards.html
+++ b/tickit-devices/rename-component/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/developer/tutorials/dev-install.html
+++ b/tickit-devices/rename-component/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/genindex.html
+++ b/tickit-devices/rename-component/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/index.html
+++ b/tickit-devices/rename-component/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/index.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/py-modindex.html
+++ b/tickit-devices/rename-component/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/search.html
+++ b/tickit-devices/rename-component/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/search.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/user/explanations/docs-structure.html
+++ b/tickit-devices/rename-component/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/user/how-to/run-container.html
+++ b/tickit-devices/rename-component/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/user/index.html
+++ b/tickit-devices/rename-component/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/user/reference/api.html
+++ b/tickit-devices/rename-component/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/rename-component/user/tutorials/installation.html
+++ b/tickit-devices/rename-component/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/rename-component/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/rename-component/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/rename-component/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/_static/webpack-macros.html
+++ b/tickit-devices/signal-generator/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/explanations/decisions.html
+++ b/tickit-devices/signal-generator/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/signal-generator/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/signal-generator/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/build-docs.html
+++ b/tickit-devices/signal-generator/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/contribute.html
+++ b/tickit-devices/signal-generator/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/lint.html
+++ b/tickit-devices/signal-generator/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/make-release.html
+++ b/tickit-devices/signal-generator/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/pin-requirements.html
+++ b/tickit-devices/signal-generator/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/run-tests.html
+++ b/tickit-devices/signal-generator/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/static-analysis.html
+++ b/tickit-devices/signal-generator/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/test-container.html
+++ b/tickit-devices/signal-generator/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/how-to/update-tools.html
+++ b/tickit-devices/signal-generator/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/index.html
+++ b/tickit-devices/signal-generator/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/reference/standards.html
+++ b/tickit-devices/signal-generator/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/developer/tutorials/dev-install.html
+++ b/tickit-devices/signal-generator/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/genindex.html
+++ b/tickit-devices/signal-generator/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/index.html
+++ b/tickit-devices/signal-generator/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/index.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/py-modindex.html
+++ b/tickit-devices/signal-generator/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/search.html
+++ b/tickit-devices/signal-generator/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/search.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/user/explanations/docs-structure.html
+++ b/tickit-devices/signal-generator/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/user/how-to/run-container.html
+++ b/tickit-devices/signal-generator/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/user/index.html
+++ b/tickit-devices/signal-generator/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/user/reference/api.html
+++ b/tickit-devices/signal-generator/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/signal-generator/user/tutorials/installation.html
+++ b/tickit-devices/signal-generator/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/signal-generator/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/signal-generator/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/signal-generator/user/tutorials/installation.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/_static/webpack-macros.html
+++ b/tickit-devices/trigger-eiger/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/_static/webpack-macros.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/explanations/decisions.html
+++ b/tickit-devices/trigger-eiger/developer/explanations/decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html
+++ b/tickit-devices/trigger-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0001-record-architecture-decisions.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
+++ b/tickit-devices/trigger-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/explanations/decisions/0002-switched-to-pip-skeleton.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/build-docs.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/build-docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/build-docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/build-docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/build-docs.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/contribute.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/contribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/contribute.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/contribute.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/contribute.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/lint.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/lint.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/lint.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/lint.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/lint.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/make-release.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/make-release.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/make-release.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/make-release.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/make-release.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/pin-requirements.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/pin-requirements.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/pin-requirements.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/pin-requirements.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/pin-requirements.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/run-tests.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/run-tests.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/run-tests.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/run-tests.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/run-tests.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/static-analysis.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/static-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/static-analysis.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/static-analysis.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/static-analysis.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/test-container.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/test-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/test-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/test-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/test-container.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/how-to/update-tools.html
+++ b/tickit-devices/trigger-eiger/developer/how-to/update-tools.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/update-tools.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/update-tools.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/how-to/update-tools.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/index.html
+++ b/tickit-devices/trigger-eiger/developer/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/index.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/reference/standards.html
+++ b/tickit-devices/trigger-eiger/developer/reference/standards.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/reference/standards.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/reference/standards.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/reference/standards.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/developer/tutorials/dev-install.html
+++ b/tickit-devices/trigger-eiger/developer/tutorials/dev-install.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/tutorials/dev-install.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/tutorials/dev-install.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/developer/tutorials/dev-install.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/genindex.html
+++ b/tickit-devices/trigger-eiger/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/genindex.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/index.html
+++ b/tickit-devices/trigger-eiger/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/index.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/py-modindex.html
+++ b/tickit-devices/trigger-eiger/py-modindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/py-modindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/py-modindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/py-modindex.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/search.html
+++ b/tickit-devices/trigger-eiger/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/search.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/user/explanations/docs-structure.html
+++ b/tickit-devices/trigger-eiger/user/explanations/docs-structure.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/explanations/docs-structure.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/explanations/docs-structure.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/explanations/docs-structure.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/user/how-to/run-container.html
+++ b/tickit-devices/trigger-eiger/user/how-to/run-container.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/how-to/run-container.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/how-to/run-container.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/how-to/run-container.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/user/index.html
+++ b/tickit-devices/trigger-eiger/user/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/index.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/user/reference/api.html
+++ b/tickit-devices/trigger-eiger/user/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/reference/api.html">
+  </head>
+</html>

--- a/tickit-devices/trigger-eiger/user/tutorials/installation.html
+++ b/tickit-devices/trigger-eiger/user/tutorials/installation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/tutorials/installation.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/tutorials/installation.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/tickit-devices/trigger-eiger/user/tutorials/installation.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/tickit-devices` using https://gitlab.diamond.ac.uk/github/github-scripts