### PR TITLE
Added redirects for pmacFilterControl

### DIFF
--- a/pmacFilterControl/_static/webpack-macros.html
+++ b/pmacFilterControl/_static/webpack-macros.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/_static/webpack-macros.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/_static/webpack-macros.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/_static/webpack-macros.html">
+  </head>
+</html>

--- a/pmacFilterControl/explanations/interface.html
+++ b/pmacFilterControl/explanations/interface.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/explanations/interface.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/explanations/interface.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/explanations/interface.html">
+  </head>
+</html>

--- a/pmacFilterControl/explanations/overview.html
+++ b/pmacFilterControl/explanations/overview.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/explanations/overview.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/explanations/overview.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/explanations/overview.html">
+  </head>
+</html>

--- a/pmacFilterControl/genindex.html
+++ b/pmacFilterControl/genindex.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/genindex.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/genindex.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/genindex.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/development.html
+++ b/pmacFilterControl/how-to/development.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/development.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/development.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/development.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/development/ppmac_config.html
+++ b/pmacFilterControl/how-to/development/ppmac_config.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_config.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_config.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_config.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/development/ppmac_cross_compiling.html
+++ b/pmacFilterControl/how-to/development/ppmac_cross_compiling.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_cross_compiling.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_cross_compiling.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_cross_compiling.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/development/ppmac_deploy.html
+++ b/pmacFilterControl/how-to/development/ppmac_deploy.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_deploy.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_deploy.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/development/ppmac_deploy.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/docs.html
+++ b/pmacFilterControl/how-to/docs.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/docs.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/docs.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/docs.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/excalidraw.html
+++ b/pmacFilterControl/how-to/excalidraw.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/excalidraw.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/excalidraw.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/excalidraw.html">
+  </head>
+</html>

--- a/pmacFilterControl/how-to/index.html
+++ b/pmacFilterControl/how-to/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/how-to/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/how-to/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/how-to/index.html">
+  </head>
+</html>

--- a/pmacFilterControl/index.html
+++ b/pmacFilterControl/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/index.html">
+  </head>
+</html>

--- a/pmacFilterControl/reference/api.html
+++ b/pmacFilterControl/reference/api.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/reference/api.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/reference/api.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/reference/api.html">
+  </head>
+</html>

--- a/pmacFilterControl/reference/design_spec.html
+++ b/pmacFilterControl/reference/design_spec.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/reference/design_spec.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/reference/design_spec.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/reference/design_spec.html">
+  </head>
+</html>

--- a/pmacFilterControl/reference/index.html
+++ b/pmacFilterControl/reference/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/reference/index.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/reference/index.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/reference/index.html">
+  </head>
+</html>

--- a/pmacFilterControl/search.html
+++ b/pmacFilterControl/search.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://diamondlightsource.github.io/pmacFilterControl/search.html</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://diamondlightsource.github.io/pmacFilterControl/search.html">
+    <link rel="canonical" href="https://diamondlightsource.github.io/pmacFilterControl/search.html">
+  </head>
+</html>


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/pmacFilterControl` using https://gitlab.diamond.ac.uk/github/github-scripts